### PR TITLE
fix: Remove optional API reference causing buid failure

### DIFF
--- a/.github/workflows/azure-static-web-apps-lemon-plant-0a67eab03.yml
+++ b/.github/workflows/azure-static-web-apps-lemon-plant-0a67eab03.yml
@@ -27,8 +27,8 @@ jobs:
           action: "upload"
           ###### Repository/Build Configurations - These values can be configured to match you app requirements. ######
           # For more information regarding Static Web App workflow configurations, please visit: https://aka.ms/swaworkflowconfig
-          app_location: "/react-app" # App source code path
-          api_location: "/azure-function" # Api source code path - optional
+          app_location: "/react-app"   # App source code path
+          api_location: "/na"          # Api source code path - optional (set to inexistent path to not trigger Python run - Azure Function deployment in separate yml file)
           app_artifact_location: "" # Built app content directory - optional
           ###### End of Repository/Build Configurations ######
 


### PR DESCRIPTION
Build started failing - issue caused by optional API step that invokes Python. Resolved by changing optional yml parameter to inexistent folder (removing the parameter entirely did not resolve it since the build automatically detected it).