### PR TITLE
fix: Update URL to default domain

### DIFF
--- a/react-app/src/components/SelectMenu/SelectMenu.tsx
+++ b/react-app/src/components/SelectMenu/SelectMenu.tsx
@@ -94,7 +94,7 @@ export const SelectMenu: FC = () => {
           </div>
           <a
             href={ // for local testing replace with http://localhost:7071/api
-              "https://api.yield-curves.com/api/yield-curve?date=" +
+              "https://yield-curve-functions.azurewebsites.net/api/yield-curve?date=" +
               lastDay +
               "&filter=country_code eq '" +
               options[selectedCountry] +

--- a/react-app/src/components/Subscribe/Subscribe.tsx
+++ b/react-app/src/components/Subscribe/Subscribe.tsx
@@ -10,7 +10,7 @@ export const Subscription: FC = () => {
    * @param email User e-mail
    */
   const submitEmail = async (email: string) => {
-    const response = await fetch("https://api.yield-curves.com/api/register", {
+    const response = await fetch("https://yield-curve-functions.azurewebsites.net/api/register", {
       method: "POST",
       body: JSON.stringify({ email: email }),
     });

--- a/react-app/src/views/Home.tsx
+++ b/react-app/src/views/Home.tsx
@@ -44,7 +44,7 @@ export const Home: FC = () => {
       // Fetch data from REST API
       const response = await fetch(
         // for local testing replace with http://localhost:7071/api
-        "https://api.yield-curves.com/api/yield-curve?date=2020-06-30&filter=country_code eq 'US' or country_code eq 'GB' or country_code eq 'CN' or country_code eq 'CH' or country_code eq 'JP' or country_code eq 'NO' or country_code eq 'DE' or country_code eq 'RU' or country_code eq 'AU' or country_code eq 'HK' or country_code eq 'SG'"
+        "https://yield-curve-functions.azurewebsites.net/api/yield-curve?date=2020-06-30&filter=country_code eq 'US' or country_code eq 'GB' or country_code eq 'CN' or country_code eq 'CH' or country_code eq 'JP' or country_code eq 'NO' or country_code eq 'DE' or country_code eq 'RU' or country_code eq 'AU' or country_code eq 'HK' or country_code eq 'SG'"
       );
 
       // Extract json


### PR DESCRIPTION
In Chrome browsers (desktop & mobile) the chart is not loaded. The root cause is a missing certificate for the custom subdomain. As a quick fix this pull reqest uses the trusted azurewebsites domain until a SSL certificate is set up for the custom domain.

**Issue**
![image](https://user-images.githubusercontent.com/10134699/88431330-61875a80-cdfa-11ea-837c-0c7fbd0f9397.png)

**Domains**
![image](https://user-images.githubusercontent.com/10134699/88431335-651ae180-cdfa-11ea-958e-bac802cb39a6.png)

