### PR TITLE
fix: Chart positioning and wrapping on mobile devices

### DIFF
--- a/react-app/src/components/Widgets/YieldCurveWidget.tsx
+++ b/react-app/src/components/Widgets/YieldCurveWidget.tsx
@@ -49,7 +49,7 @@ export const YieldCurveWidget: FC<YieldCurveWidgetProps> = ({ data }) => {
 
   return (
     <>
-      <div style={{ height: 450 }} className="w-4/5 mx-auto mt-24">
+      <div style={{ height: 450 }} className="mx-auto -mr-6 md:mr-8 md:mt-6 md:w-11/12">
         <ResponsiveLine
           data={selectedData}
           theme={theme}
@@ -113,10 +113,10 @@ export const YieldCurveWidget: FC<YieldCurveWidgetProps> = ({ data }) => {
           ]}
         />
       </div>
-      <div className="flex justify-center ml-6">
+      <div className="flex flex-wrap px-4 mx-auto md:w-4/5">
           {data.map((d) => (
             <button key={d.id}
-              className={clsx("p-2 mx-1 my-2 text-white rounded-md hover:bg-teal-500 focus:outline-none shadow-inner", {
+              className={clsx("ml-1 mt-1 w-10 h-10 text-white rounded-md hover:bg-teal-500 focus:outline-none shadow-inner", {
                 "bg-teal-600": country === d.id,
                 "bg-gray-700": country !== d.id,
               })}

--- a/react-app/src/components/Widgets/YieldCurveWidget.tsx
+++ b/react-app/src/components/Widgets/YieldCurveWidget.tsx
@@ -114,7 +114,7 @@ export const YieldCurveWidget: FC<YieldCurveWidgetProps> = ({ data }) => {
         />
       </div>
       <div className="flex flex-wrap px-4 mx-auto md:w-4/5">
-          {data.map((d) => (
+          {data.sort((a, b) => (a.id > b.id ? 1 : -1)).map((d) => (
             <button key={d.id}
               className={clsx("ml-1 mt-1 w-10 h-10 text-white rounded-md hover:bg-teal-500 focus:outline-none shadow-inner", {
                 "bg-teal-600": country === d.id,

--- a/react-app/src/views/Home.tsx
+++ b/react-app/src/views/Home.tsx
@@ -156,7 +156,7 @@ export const Home: FC = () => {
           </div>
         </div>
         <div
-          className="bg-gray-800 lg:pl-32 lg:absolute lg:inset-y-0 lg:left-1/2 lg:w-1/2 lg:max-w-4xl"
+          className="py-6 bg-gray-800 md:py-12 lg:pl-32 lg:absolute lg:inset-y-0 lg:left-1/2 lg:w-1/2 lg:max-w-4xl"
           style={{
             backgroundColor: "#252f3f",
             backgroundImage:


### PR DESCRIPTION
On mobile devices the chart positioning as well as the country list were not optimal. Now the country list is wrapped on narrow devices and charts are making better use of the available space.