### PR TITLE
fix: Set environment variables in build pipeline

### DIFF
--- a/.github/workflows/azure-static-web-apps-lemon-plant-0a67eab03.yml
+++ b/.github/workflows/azure-static-web-apps-lemon-plant-0a67eab03.yml
@@ -9,6 +9,11 @@ on:
     branches:
       - master
 
+# Environment variables
+env:
+  REACT_APP_APPINSIGHTS_INSTRUMENTATION_KEY: ${{ secrets.APPINSIGHTS_INSTRUMENTATION_KEY }}   # Application Insights key
+  REACT_APP_GOOGLE_ANALYTICS_TRACKING_ID: ${{ secrets.GOOGLE_ANALYTICS_TRACKING_ID }}         # Google Analytics tracking code
+
 jobs:
   build_and_deploy_job:
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ on:
 env:
   AZURE_FUNCTIONAPP_NAME: yield-curve-functions         # Azure Functions app name
   AZURE_FUNCTIONAPP_PACKAGE_PATH: './azure-function'    # Azure Functions source folder
+  REACT_APP_APPINSIGHTS_INSTRUMENTATION_KEY: ${{ secrets.APPINSIGHTS_INSTRUMENTATION_KEY }}   # Application Insights key
+  REACT_APP_GOOGLE_ANALYTICS_TRACKING_ID: ${{ secrets.GOOGLE_ANALYTICS_TRACKING_ID }}         # Google Analytics tracking code
 
 jobs:
   # Build package


### PR DESCRIPTION
With PR #35 the React app uses environment variables to store keys in the .env file. However it missed out adding the environment variables to the CI pipeline which is now handled in this fix. The keys are stored in Github's secret store.