### PR TITLE
refactor: Use Link component instead fo anchor tag for internal references

### DIFF
--- a/react-app/src/components/Pricing/PricingCardBudget.tsx
+++ b/react-app/src/components/Pricing/PricingCardBudget.tsx
@@ -1,6 +1,7 @@
 import React, { FC } from "react";
 import { PricingCardProps } from "./PricingCardProps";
 import { CheckmarkIcon } from "./CheckMarkIcon";
+import { Link } from "react-router-dom";
 
 /**
  * Leftmost pricing card for budget offer
@@ -38,12 +39,12 @@ export const PricingCardBudget: FC<PricingCardProps> = ({ title, amount, benefit
             </ul>
             <div className="mt-8">
               <div className="rounded-lg shadow-md">
-                <a
-                  href={buttonUrl}
+                <Link
+                  to={buttonUrl}
                   className="block w-full px-6 py-3 text-base font-medium leading-6 text-center text-indigo-600 transition duration-150 ease-in-out bg-white border border-transparent rounded-lg hover:text-indigo-100 hover:bg-indigo-600 focus:outline-none focus:shadow-outline"
                   aria-describedby="tier-hobby">
                   {buttonText}
-                </a>
+                </Link>
               </div>
             </div>
           </div>

--- a/react-app/src/components/Pricing/PricingCardMain.tsx
+++ b/react-app/src/components/Pricing/PricingCardMain.tsx
@@ -1,6 +1,7 @@
 import React, { FC } from "react";
 import { PricingCardProps } from "./PricingCardProps";
 import { CheckmarkIcon } from "./CheckMarkIcon";
+import { Link } from "react-router-dom";
 
 /**
  * Central pricing card for main offer
@@ -45,12 +46,12 @@ export const PricingCardMain: FC<PricingCardProps> = ({ title, amount, benefits,
           </ul>
           <div className="mt-10">
             <div className="rounded-lg shadow-md">
-              <a
-                href={buttonUrl}
+              <Link
+                to={buttonUrl}
                 className="block w-full px-6 py-4 text-xl font-medium leading-6 text-center text-white transition duration-150 ease-in-out bg-indigo-600 border border-transparent rounded-lg hover:bg-indigo-500 focus:outline-none focus:border-indigo-700 focus:shadow-outline-indigo"
                 aria-describedby="tier-growth">
                 {buttonText}
-              </a>
+              </Link>
             </div>
           </div>
         </div>

--- a/react-app/src/components/Pricing/PricingCardTop.tsx
+++ b/react-app/src/components/Pricing/PricingCardTop.tsx
@@ -1,6 +1,7 @@
 import React, { FC } from "react";
 import { PricingCardProps } from "./PricingCardProps";
 import { CheckmarkIcon } from "./CheckMarkIcon";
+import { Link } from "react-router-dom";
 
 /**
  * Rightmost pricing card for top offer
@@ -38,12 +39,12 @@ export const PricingCardTop: FC<PricingCardProps> = ({ title, amount, benefits, 
             </ul>
             <div className="mt-8">
               <div className="rounded-lg shadow-md">
-                <a
-                  href={buttonUrl}
+                <Link
+                  to={buttonUrl}
                   className="block w-full px-6 py-3 text-base font-medium leading-6 text-center text-indigo-600 transition duration-150 ease-in-out bg-white border border-transparent rounded-lg hover:text-indigo-100 hover:bg-indigo-600 focus:outline-none focus:shadow-outline"
                   aria-describedby="tier-scale">
                   {buttonText}
-                </a>
+                </Link>
               </div>
             </div>
           </div>


### PR DESCRIPTION
To avoid full page re-render use Link component instead of anchor tag when staying within the React app.