### PR TITLE
build: Exclude large css file from repo language indexing

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+**/main.css linguist-vendored


### PR DESCRIPTION
Add gitattributes file to exclude tailwindcss output from language indexing