### PR TITLE
build: Ignore tailwindcss output in git

### DIFF
--- a/react-app/.gitignore
+++ b/react-app/.gitignore
@@ -1,5 +1,9 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
+# Ignore tailwindcss output
+# See also https://github.com/tailwindlabs/discuss/issues/352#issuecomment-545606781
+**/main.css
+
 # dependencies
 /node_modules
 /.pnp

--- a/react-app/package-lock.json
+++ b/react-app/package-lock.json
@@ -7238,6 +7238,11 @@
         }
       }
     },
+    "html-tags": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.1.0.tgz",
+      "integrity": "sha512-1qYz89hW3lFDEazhjW0yVAV87lw8lVkrJocr72XmBkMKsoSVJCQx3W8BXsC7hO2qAt8BoVjYjtAcZ9perqGnNg=="
+    },
     "html-webpack-plugin": {
       "version": "4.0.0-beta.11",
       "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-4.0.0-beta.11.tgz",
@@ -13766,9 +13771,9 @@
       }
     },
     "tailwindcss": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-1.7.3.tgz",
-      "integrity": "sha512-e6o/qhn80hcJ+cB1jIK3C1xlDPkFHU98c2m4ONMfeIOf8jvKQ+bowD39QKsWN+JMOvfATtMjgScpjSaqO1hffQ==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-1.8.2.tgz",
+      "integrity": "sha512-Acz4b2caMlrnv9zCmmwENjcktV7rblaMYGwGUT6woqmwnttLZ9ePj7yynSCln/Aky/4SGyduf7y3yk/QZNw+vw==",
       "requires": {
         "@fullhuman/postcss-purgecss": "^2.1.2",
         "autoprefixer": "^9.4.5",
@@ -13778,7 +13783,8 @@
         "color": "^3.1.2",
         "detective": "^5.2.0",
         "fs-extra": "^8.0.0",
-        "lodash": "^4.17.15",
+        "html-tags": "^3.1.0",
+        "lodash": "^4.17.20",
         "node-emoji": "^1.8.1",
         "normalize.css": "^8.0.1",
         "object-hash": "^2.0.3",
@@ -13830,9 +13836,9 @@
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
         },
         "supports-color": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "requires": {
             "has-flag": "^4.0.0"
           }

--- a/react-app/package.json
+++ b/react-app/package.json
@@ -36,7 +36,7 @@
     "react-router-dom": "^5.2.0",
     "react-scripts": "^3.4.3",
     "react-transition-group": "^4.4.1",
-    "tailwindcss": "^1.7.3",
+    "tailwindcss": "^1.8.2",
     "typescript": "^3.9.7"
   },
   "scripts": {


### PR DESCRIPTION
Tailwindcss builds a css file during development server start and deployment. Since the file is heavy (~200k lines of code) and changes with every update of the framework it's [recommended to not track it in git](https://github.com/tailwindlabs/discuss/issues/352#issuecomment-545606781).